### PR TITLE
fix for windows

### DIFF
--- a/lib/helpers.coffee
+++ b/lib/helpers.coffee
@@ -22,6 +22,12 @@ exports.spawnUntilEmpty = (commands, callback) ->
 
     command = spawn(commandDescriptor.name, commandDescriptor.args,
                     commandDescriptor.opts)
+                    
+    if os.platform().match /^win/
+        name = commandDescriptor.name
+        commandDescriptor.name = "cmd"
+        commandDescriptor.args.unshift(name)
+        commandDescriptor.args.unshift('/C')
 
     command.stdout.on 'data',  (data) ->
         console.log "#{data}"


### PR DESCRIPTION
Allow spawning of .bat files (such as Vagrant)
tested only on windows 8
