### PR TITLE
use /usr/bin/env for portability

### DIFF
--- a/bin/cozy
+++ b/bin/cozy
@@ -1,4 +1,4 @@
-#! /usr/local/bin/node
+#!/usr/bin/env node
 
 // Boostrap CLI tool
 var path = require('path'),


### PR DESCRIPTION
On Archlinux node path is "/usr/bin/node".

The "env" program improves portability 
