### PR TITLE
Fix usage of str.match

### DIFF
--- a/src/vagrant.coffee
+++ b/src/vagrant.coffee
@@ -25,7 +25,7 @@ class exports.VagrantManager
                 console.log msg.red
             else
                 versionMatch = stdout.match /Vagrant ([\d\.]+)/
-                if not versionMatch? or versionMatch.length isnt 1
+                if not versionMatch? or versionMatch.length isnt 2
                     msg = "Cannot correctly check the version using the " + \
                             "\"vagrant -v\" command. Please report an issue."
                     console.log msg.red


### PR DESCRIPTION
According to https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/match:

`The returned Array has an extra input property, which contains the original string that was parsed.`

So if there's a match, there should be 2 entries in the array (input + the match), not one. The proof is that later in the code, we use versionMatch[1] :)
