### PR TITLE
Fixed: `vagrant -v` test couldn't pass

### DIFF
--- a/src/vagrant.coffee
+++ b/src/vagrant.coffee
@@ -25,7 +25,8 @@ class exports.VagrantManager
                 console.log msg.red
             else
                 versionMatch = stdout.match /Vagrant ([\d\.]+)/
-                if not versionMatch? or versionMatch.length isnt 1
+
+                if not versionMatch?
                     msg = "Cannot correctly check the version using the " + \
                             "\"vagrant -v\" command. Please report an issue."
                     console.log msg.red


### PR DESCRIPTION
@aenario could you merge/publish the new version please? The `dev:init` command is currently broken.
