### PR TITLE
fix issue #44 - vagrant minimum version fails version check

### DIFF
--- a/src/vagrant.coffee
+++ b/src/vagrant.coffee
@@ -17,7 +17,7 @@ class exports.VagrantManager
         @docURL = "http://cozy.io/hack/getting-started/setup-environment.html"
 
         # Minimum required version to make Vagrant work with cozy-dev
-        @minimumVagrantVersion = "1.5.0"
+        @minimumVagrant = "1.5.0"
 
     checkIfVagrantIsInstalled: (callback) ->
         exec "vagrant -v", (err, stdout, stderr) =>
@@ -35,9 +35,9 @@ class exports.VagrantManager
 
                 # If the installed version of Vagrant is older than the
                 # required one, raise an error (see issue #31)
-                else if ~compareVersions @minimumVagrantVersion, versionMatch[1]
+                else if compareVersions(@minimumVagrant, versionMatch[1]) > 0
                     msg = "cozy-dev requires Vagrant " + \
-                            "#{@minimumVagrantVersion} or later."
+                            "#{@minimumVagrant} or later."
                     log.error msg.red
                 else
                     callback() if callback?


### PR DESCRIPTION
Adjusts vagrant version check so installed versions equal to or greater than the minimum will pass.

When the installed version of vagrant exactly matches the minimum version (currently 1.5.0), the version check fails and vm:init exits with the error, "cozy-dev requires Vagrant 1.5.0 or later." This is because mozilla-version-comparator returns 0 when the compared versions are exactly equal (versions greater than the minimum return -1, while lesser versions return 1). Truth checking the bitwise NOT of 0 (which is -1) returns true and enters the error condition. Instead, just enter the error condition if the result of the comparison is greater than zero.

(BTW, shortening @minimumVagrantVersion to @minimumVagrant was only necessary to stay within the 80 character line length, while still keeping the relevant code together.)
