### PR TITLE
Fix current process directory when running vagrant ssh-config

### DIFF
--- a/src/vagrant.coffee
+++ b/src/vagrant.coffee
@@ -171,12 +171,18 @@ class exports.VagrantManager
         cmd =
             name: 'vagrant'
             args: ['ssh-config']
-        sshConfig = spawn cmd.name, cmd.args, cwd: __dirname
+        sshConfig = spawn cmd.name, cmd.args, cwd: process.cwd()
         sshConfig.stdout.on 'data', (data) ->
             config += data.toString()
 
+        maybeErr = ''
+        sshConfig.stderr.on 'data', (data) ->
+            maybeErr += data
+
         sshConfig.on 'close', (err) ->
-            if config is ''
+            if maybeErr isnt ''
+                callback maybeErr
+            else if config is ''
                 callback 'No config'
             else
                 configs = config.split('\n')


### PR DESCRIPTION
Otherwise, I would get an error message that there is no Vagrant instance around, even with the latest Vagrant.
I've also added debug information, in case this command gets an error.