### PR TITLE
Reverted: use stream piping instead of printit for spawned commands

### DIFF
--- a/src/helpers.coffee
+++ b/src/helpers.coffee
@@ -23,15 +23,8 @@ module.exports.spawnUntilEmpty = (commands, callback) ->
         commandDescriptor.args.unshift name
         commandDescriptor.args.unshift '/C'
 
-    command.stdout.on 'data',  (data) ->
-        log = require('printit')
-            prefix: '(spawn)    '
-        log.info "#{data}".replace(/\n/g, '')
-
-    command.stderr.on 'data', (data) ->
-        log = require('printit')
-            prefix: '(spawn)   '
-        log.error "#{data}".replace(/\n/g, '')
+    command.stdout.pipe process.stdout
+    command.stderr.pipe process.stderr
 
     command.on 'close', (code, signal) ->
         if commands.length > 0 and code is 0


### PR DESCRIPTION
`util.print` is very good at outputting stdout and stderr.
I tried various things with printit, but none of them were successful. I always ended up with broken lines, unreadable logs (all on the same lines), or a mix a both. This is very noticeable during `cozy-dev vm:update` since it runs a bash script, where we don't control the output (i.e. of vagrant, npm, and pip).

I suggest we take this change, but we open an issue to make sure we do solve the problem in the best way. For instance, we could run each commands from NodeJS so we could show logs to the user, without showing it every single line of it.