### PR TITLE
Various improvements

### DIFF
--- a/coffeelint.json
+++ b/coffeelint.json
@@ -6,5 +6,11 @@
     "max_line_length" : {
         "value" : 80,
         "level" : "error"
+    },
+    "no_empty_param_list": {
+        "level": "warn"
+    },
+    "prefer_english_operator": {
+        "level": "warn"
     }
 }

--- a/src/application.coffee
+++ b/src/application.coffee
@@ -105,7 +105,7 @@ class exports.ApplicationManager
                         log.error err.red
                     else
                         funcs = []
-                        if apps? and typeof apps == "object"
+                        if apps? and typeof apps is "object"
                             funcs.push checkApp(app.name) for app in apps.rows
                             async.series funcs, callback
 
@@ -133,7 +133,8 @@ class exports.ApplicationManager
 
     removeFromDatabase: (manifest, callback) ->
         dsClient = new Client 'http://localhost:9101'
-        dsClient.post 'request/application/byslug/', {key: manifest.slug}, (err, res, body) ->
+        option = key: manifest.slug
+        dsClient.post 'request/application/byslug/', option, (err, res, body) ->
             return callback err if err? or not body?[0]?.value
             app = body[0].value
             port = app.port
@@ -149,14 +150,23 @@ class exports.ApplicationManager
                 detached: true
                 stdio: ['ignore', 'ignore', 'ignore']
             command = 'ssh'
-            args = ['-N', 'vagrant@127.0.0.1']
-            args = args.concat ['-R', "#{port}:localhost:#{port}"]
-            args = args.concat ['-p', config.Port]
-            args = args.concat ['-o', "IdentityFile=#{config.IdentityFile}"]
-            args = args.concat ['-o',"UserKnownHostsFile=#{config.UserKnownHostsFile}"]
-            args = args.concat ['-o', "StrictHostKeyChecking=#{config.StrictHostKeyChecking}"]
-            args = args.concat ['-o', "PasswordAuthentication=#{config.PasswordAuthentication}"]
-            args = args.concat ['-o', "IdentitiesOnly=#{config.IdentitiesOnly}"]
+            args = []
+            args.push '-N'
+            args.push 'vagrant@127.0.0.1'
+            args.push '-R'
+            args.push "#{port}:localhost:#{port}"
+            args.push '-p'
+            args.push config.Port
+            args.push '-o'
+            args.push "IdentityFile=#{config.IdentityFile}"
+            args.push '-o'
+            args.push "UserKnownHostsFile=#{config.UserKnownHostsFile}"
+            args.push '-o'
+            args.push "StrictHostKeyChecking=#{config.StrictHostKeyChecking}"
+            args.push '-o'
+            args.push "PasswordAuthentication=#{config.PasswordAuthentication}"
+            args.push '-o'
+            args.push "IdentitiesOnly=#{config.IdentitiesOnly}"
 
             child = spawn command, args, options
             # Retrieve pid

--- a/src/database.coffee
+++ b/src/database.coffee
@@ -7,6 +7,9 @@ log = require('printit')
 
 Client = require('request-json').JsonClient
 
+CONTROLLER_CONFIG = 'controller.json'
+CONTROLLER_CONFIG_PATH = "/etc/cozy/#{CONTROLLER_CONFIG}"
+
 module.exports = class DatabaseManager
 
 
@@ -107,3 +110,23 @@ module.exports = class DatabaseManager
             else
                 log.info "Database #{dbName} successfully reset.".green
             callback()
+
+    getCurrentDatabase: (callback) ->
+
+        command = """
+        vagrant ssh -c "sudo cat #{CONTROLLER_CONFIG_PATH}"
+        """
+        exec command, (err, stderr, stdout) ->
+            try
+                config = JSON.stringify stdout
+                databaseName = config?['data-system']?['DB_NAME']
+
+                # default is cozy
+                databaseName ?= 'cozy'
+                log.info "Current database is \"#{databaseName}\""
+                callback()
+
+            catch err
+                msg = "An error occured while getting database name"
+                log.error "#{msg} -- #{err}".red
+                callback err

--- a/src/database.coffee
+++ b/src/database.coffee
@@ -12,43 +12,45 @@ module.exports = class DatabaseManager
 
     switch: (newName, callback) ->
 
-        fileName = 'controller.json'
-        filePath = "/etc/cozy/#{fileName}"
-
-        async.series
-
-            getConfig: (next) ->
+        async.waterfall [
+            # get config
+            (next) ->
                 command = """
-                vagrant ssh -c "sudo cp #{filePath} /vagrant/"
+                vagrant ssh -c "sudo cat #{CONTROLLER_CONFIG_PATH} 1>&2"
                 """
                 log.info 'Getting current configuration...'
                 exec command, (err, stderr, stdout) ->
-                    if err? or stderr
-                        err = err or stderr
+                    if err?
                         next err
                     else
-                        next()
+                        next null, stdout
 
-            updateConfig: (next) ->
+            # update config
+            (rawConfig, next) ->
                 try
-                    options = encoding: 'utf-8'
-                    rawConfig = fs.readFileSync './controller.json', options
+                    # Extract JSON from controller configuration
                     config = JSON.parse rawConfig
                     config.env ?= {}
 
                     unless config.env['data-system']
                         config.env['data-system'] = {}
 
+                    # Override DB_NAME configuration
                     config.env['data-system']['DB_NAME'] = newName
-                    newRawConfig = JSON.stringify config
-                    fs.writeFileSync './controller.json', newRawConfig
-                    next()
+                    newRawConfig = JSON.stringify config, null, ' '
+                    next null, newRawConfig
                 catch err
                     next err
 
-            writeConfig: (next) ->
+            # write config
+            (rawConfig, next) ->
+                # escape JSON for the bash command
+                rawConfig = rawConfig.replace /"/g, "\""
+                subCommand = """
+                echo \\"#{rawConfig}\\" >> sudo #{CONTROLLER_CONFIG_PATH}
+                """
                 command = """
-                vagrant ssh -c "sudo mv /vagrant/#{fileName} #{filePath}"
+                vagrant ssh -c "#{subCommand}"
                 """
                 log.info 'Updating new configuration...'
                 exec command, (err, stderr, stdout) ->
@@ -58,7 +60,8 @@ module.exports = class DatabaseManager
                     else
                         next()
 
-            restartController: (next) ->
+            # restart controller
+            (next) ->
                 command = """
                 vagrant ssh -c "sudo supervisorctl restart cozy-controller"
                 """
@@ -67,12 +70,13 @@ module.exports = class DatabaseManager
                     # supervisor outputs its logs to stderr...
                     next err
 
-        , (err) ->
+        ], (err) ->
             if err?
                 msg = "An error occured while changing Cozy's configuration"
                 log.error "#{msg} -- #{err}".red
             else
                 log.info "Database successfully switched to #{newName}".green
+
             callback()
 
 

--- a/src/helpers.coffee
+++ b/src/helpers.coffee
@@ -38,7 +38,7 @@ isStarted = module.exports.isStarted = (callback) ->
     client = new Client url
     client.get '/status', (err, res, body) ->
         if err
-            setTimeout () ->
+            setTimeout ->
                 isStarted callback
             , 1 * 1000
         else
@@ -56,7 +56,10 @@ module.exports.promptPassword = (name) -> (cb) ->
 
 module.exports.getPidFile = (name) ->
     if module.exports.isRunningOnWindows()
-        home = process.env.HOME or process.env.HOMEPATH or process.env.USERPROFILE
-        return path.join(home, "#{name}.pid")
+        home =
+            process.env.HOME or
+            process.env.HOMEPATH or
+            process.env.USERPROFILE
+        return path.join home, "#{name}.pid"
     else
-        return path.join('/tmp', "#{name}.pid")
+        return path.join '/tmp', "#{name}.pid"

--- a/src/main.coffee
+++ b/src/main.coffee
@@ -291,6 +291,7 @@ program
                 (cb) ->
                     log.info "Start the new virtual machine..."
                     vagrantManager.vagrantUp (code) -> cb null, code
+                (cb) -> databaseManager.getCurrentDatabase cb
             ], (err, results) ->
                 if err
                     log.info err

--- a/src/main.coffee
+++ b/src/main.coffee
@@ -366,6 +366,15 @@ program
                 process.exit 0
 
 program
+.command "db:name"
+.description "Returns the current used database"
+.action ->
+    databaseManager.getCurrentDatabase (err) ->
+        returnCode = if err? then 1 else 0
+        process.exit returnCode
+
+
+program
 .command "*"
 .description "Display help message for an unknown command."
 .action ->

--- a/src/main.coffee
+++ b/src/main.coffee
@@ -100,14 +100,20 @@ program
 
 # Install application for cozy stack
 program
-.command "deploy [port]"
+.command "deploy [port] [slug]"
 .description "Push code and deploy app located in current directory " + \
              "to your virtualbox."
-.action (port) ->
+.action (port, slug) ->
     port = 9250 unless port?
     # Recover manifest
     projectManager.recoverManifest port, (err, app) ->
-        return console.log err if err?
+        return log.error err if err?
+
+        # Slug can be overriden by command's parameter
+        if slug?
+            app.name = slug
+            app.slug = slug
+            app.displayName += " (#{slug})"
 
         if app.name in ['home', 'data-system', 'proxy']
             # Stack application
@@ -132,12 +138,18 @@ program
 
 # Uninstall application for cozy stack
 program
-.command "undeploy"
+.command "undeploy [slug]"
 .description "Undeploy application"
-.action () ->
+.action (slug) ->
     # Recover manifest
     projectManager.recoverManifest 9250, (err, app) ->
-        return console.log err if err?
+        return log.error err if err?
+
+        # Slug can be overriden by command's parameter
+        if slug?
+            app.name = slug
+            app.slug = slug
+            app.displayName += " (#{slug})"
 
         if app.name in ['home', 'data-system', 'proxy']
             # Stack application

--- a/src/main.coffee
+++ b/src/main.coffee
@@ -117,24 +117,25 @@ program
 
         if app.name in ['home', 'data-system', 'proxy']
             # Stack application
-            async.series [
+            steps = [
                 (cb) -> appManager.stopApp app.name, cb
                 (cb) -> appManager.addPortForwarding app.name, app.port, cb
-            ], (err) ->
-                return console.log err if err?
-                msg = "Application deployed in virtual machine."
-                log.info msg.green
-
+            ]
         else
             # User application
-            async.series [
+            steps = [
                 (cb) -> appManager.addInDatabase app, cb
                 (cb) -> appManager.resetProxy cb
                 (cb) -> appManager.addPortForwarding app.name, app.port, cb
-            ], (err) ->
-                return console.log err if err?
-                msg = "Application deployed in virtual machine."
-                log.info msg.green
+            ]
+
+        async.series steps, (err) ->
+            return log.error err if err?
+            msg = "Application deployed in virtual machine."
+            log.info msg.green
+
+            appUrl = "http://localhost:9104/#apps/#{app.slug}"
+            log.info "You can see your app on #{appUrl}"
 
 # Uninstall application for cozy stack
 program
@@ -153,23 +154,22 @@ program
 
         if app.name in ['home', 'data-system', 'proxy']
             # Stack application
-            async.series [
+            steps = [
                 (cb) -> appManager.removePortForwarding app.name, app.port, cb
                 (cb) -> appManager.startApp app.name, cb
-            ], (err) ->
-                return console.log err if err?
-                msg = "Application undeployed in virtual machine."
-                log.info msg.green
+            ]
         else
             # User application
-            async.series [
+            steps = [
                 (cb) -> appManager.removeFromDatabase app, cb
                 (cb) -> appManager.resetProxy cb
                 (cb) -> appManager.removePortForwarding app.name, app.port, cb
-            ], (err) ->
-                return console.log err if err?
-                msg = "Application undeployed in virtual machine."
-                log.info msg.green
+            ]
+
+        async.series steps, (err) ->
+            return log.error err if err?
+            msg = "Application undeployed in virtual machine."
+            log.info msg.green
 
 program
 .command "vm:init"

--- a/src/vagrant.coffee
+++ b/src/vagrant.coffee
@@ -84,7 +84,7 @@ class exports.VagrantManager
             args: ['up']
         helpers.spawnUntilEmpty cmds, (code) ->
             log.info "Checking status ..."
-            helpers.isStarted () ->
+            helpers.isStarted ->
                 callback code
 
     vagrantHalt: (callback)  ->
@@ -121,7 +121,7 @@ class exports.VagrantManager
             name: 'vagrant'
             args: ['ssh', '-c', '~/update-devenv.sh']
 
-        @importVagrantFile () ->
+        @importVagrantFile ->
             helpers.spawnUntilEmpty cmds, callback
 
     importVagrantFile: (callback) ->


### PR DESCRIPTION
I did it this week-end, thought it'd be nice to push a little bit forward what we did during the last sprint.

* `deploy` has a parameter to choose the app's slug, (useful for @m4dz :))
* `deploy` shows the URL where the application is accessible from
* new command: `db:name` to get which database the VM is using
* `db:name` is called at the end of `vm:start`
* improvement to `db:switch` so the code is less complicated, and works in more cases
* linted!