### PR TITLE
Fix type in icon handling

### DIFF
--- a/src/project.coffee
+++ b/src/project.coffee
@@ -82,7 +82,7 @@ class exports.ProjectManager
 
             if manifest['icon-path'] and fs.existsSync manifest['icon-path']
                 # Icon defined in package.json
-                manfest.iconPath = manifest['icon-path']
+                manifest.iconPath = manifest['icon-path']
                 manifest.iconType = 'png'
 
             else if fs.existsSync(svgPath)


### PR DESCRIPTION
This fixes an exception when using `deploy` command when manifest contains a `icon-path`.