### PR TITLE
Support server-less apps deploy

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,13 +33,14 @@
     "prepublish": "cake build"
   },
   "dependencies": {
-    "commander": "2.4.0",
     "async": "0.9.0",
-    "request-json": "0.4.13",
     "colors": "0.6.2",
-    "mozilla-version-comparator": "1.0.2",
-    "printit": "0.1.3",
+    "commander": "2.4.0",
     "inquirer": "0.8.0",
+    "mozilla-version-comparator": "1.0.2",
+    "parentpath": "0.2.0",
+    "printit": "0.1.3",
+    "request-json": "0.4.13",
     "semver": "4.3.1"
   },
   "devDependencies": {

--- a/src/main.coffee
+++ b/src/main.coffee
@@ -101,9 +101,10 @@ program
 # Install application for cozy stack
 program
 .command "deploy <port> [slug]"
-.description "Push code and deploy app located in current directory " + \
-             "to your virtualbox. Argument port correspond to port used" + \
-             "by your application."
+.description """Push code and deploy app located in current directory to your \
+             virtualbox. Argument port correspond to port used by your \
+             application, or to the path containing your built static assets \
+             for a server-less app."""
 .action (port, slug) ->
     port = 9250 unless port?
     # Recover manifest
@@ -127,7 +128,7 @@ program
             steps = [
                 (cb) -> appManager.addInDatabase app, cb
                 (cb) -> appManager.resetProxy cb
-                (cb) -> appManager.addPortForwarding app.name, app.port, cb
+                (cb) -> appManager.configLocalApp 'add', app, cb
             ]
 
         async.series steps, (err) ->
@@ -165,7 +166,7 @@ program
             steps = [
                 (cb) -> appManager.removeFromDatabase app, cb
                 (cb) -> appManager.resetProxy cb
-                (cb) -> appManager.removePortForwarding app.name, app.port, cb
+                (cb) -> appManager.configLocalApp 'remove', app, cb
             ]
 
         async.series steps, (err) ->

--- a/src/project.coffee
+++ b/src/project.coffee
@@ -73,7 +73,10 @@ class exports.ProjectManager
             manifest.autostop = false
             manifest.password = 'test'
             manifest.docType = "Application"
+            manifest.type = manifest["cozy-type"] or {}
             manifest.port = port
+            if manifest.type is 'static'
+                manifest.path = "/srv/#{manifest.slug.toLowerCase()}"
 
             # Recover icon
             basePath = path.join process.cwd(), "client", "app", "assets", "icons"


### PR DESCRIPTION
This PR let devs now deploy server-less apps like std apps. Simply use the `deploy` command but pass the path to the built assets instead of a port number. E.g.:

```sh
$ cozy-dev deploy my-app public    # map `public` folder as root for my-app
$ cozy-dev deploy my-app .         # map current folder as root
```

The `undeploy` command works as well.

_Note_: your app *must* be available in the `/vagrant` folder (i.e. in a subdir behing the dir containing the Vagrantfile in your host) to let mapping works.