### PR TITLE
Better error when Vagrantfile could not be found in parent path for static app deploy

### DIFF
--- a/src/application.coffee
+++ b/src/application.coffee
@@ -219,11 +219,14 @@ class exports.ApplicationManager
     # Link the app from vagrant synced_folder to app `path`
     addStaticPath: (name, appPath, callback) ->
         pp 'Vagrantfile', (dir) ->
-            appPath = "/vagrant/#{path.relative(dir, path.resolve(appPath))}"
-            srvPath = "/srv/#{name.toLowerCase()}"
+            if dir?
+                appPath = "/vagrant/#{path.relative(dir, path.resolve(appPath))}"
+                srvPath = "/srv/#{name.toLowerCase()}"
 
-            cmd = "vagrant ssh --command 'sudo ln -sf #{appPath} #{srvPath}'"
-            exec cmd, callback
+                cmd = "vagrant ssh --command 'sudo ln -sf #{appPath} #{srvPath}'"
+                exec cmd, callback
+            else
+                log.error 'Vagrantfile not found in a parent folder'
 
 
     # Remove port forward from host to virtual box for application <name>


### PR DESCRIPTION


Related to #90.